### PR TITLE
Use `AbstractArray{T}` to replace manually `Base.promote_typeof`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,8 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 julia = "1"
 
 [extras]
+IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -3,7 +3,17 @@ module Collections
 using AutoHashEquals: @auto_hash_equals
 using Unitful: AbstractQuantity, @u_str
 
-export BirchMurnaghan, BirchMurnaghan3rd, energyeos, pressureeos, bulkmoduluseos, nextorder
+export BirchMurnaghan,
+    Eulerian,
+    Lagrangian,
+    Natural,
+    Infinitesimal,
+    energyeos,
+    pressureeos,
+    bulkmoduluseos,
+    nextorder,
+    strain_from_volume,
+    volume_from_strain
 
 abstract type Parameters{T} end
 
@@ -12,13 +22,8 @@ abstract type ParametersFiniteStrain{N,T} <: Parameters{T} end
 struct BirchMurnaghan{N,T} <: ParametersFiniteStrain{N,T}
     x0::NTuple{N,T}
 end
-function BirchMurnaghan{3}(v0, b0, b′0)
-    T = Base.promote_typeof(v0, b0, b′0)
-    return BirchMurnaghan{3,T}(Tuple(convert(T, x) for x in (v0, b0, b′0)))
-end
-# BirchMurnaghan{3}(v0::Real, b0::Real, b′0::Real) = BirchMurnaghan{3}(v0, b0, b′0, 0)
-# BirchMurnaghan{3}(v0::AbstractQuantity, b0::AbstractQuantity, b′0) =
-#     BirchMurnaghan{3}(v0, b0, b′0, 0 * u"eV")
+BirchMurnaghan(arr::AbstractArray{T}) where {T} = BirchMurnaghan{length(arr),T}(Tuple(arr))
+BirchMurnaghan(args...) = BirchMurnaghan([args...])
 
 const BirchMurnaghan3rd = BirchMurnaghan{3}
 

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -25,8 +25,6 @@ end
 BirchMurnaghan(arr::AbstractArray{T}) where {T} = BirchMurnaghan{length(arr),T}(Tuple(arr))
 BirchMurnaghan(args...) = BirchMurnaghan([args...])
 
-const BirchMurnaghan3rd = BirchMurnaghan{3}
-
 function energyeos(p::BirchMurnaghan{3})
     v0, b0, b′0 = p.x0
     function (v)

--- a/test/Collections.jl
+++ b/test/Collections.jl
@@ -1,8 +1,17 @@
 module Collections
 
+using IntervalArithmetic
+using Measurements: Measurement, measurement
 using Test: @test, @testset
+using Unitful: Quantity, @u_str
 
 using EquationsOfStateOfSolids.Collections
+
+@testset "Test counstruction" begin
+    @test typeof(BirchMurnaghan(1u"angstrom^3", 3u"GPa", 4.0)) == BirchMurnaghan{3,Quantity{Float64}}
+    @test typeof(BirchMurnaghan(measurement("1 +- 0.1"), 3 // 1, 2, measurement("-123.4(56)"))) == BirchMurnaghan{4,Measurement{Float64}}
+    @test typeof(BirchMurnaghan(1..3, 2, 2..4)) == BirchMurnaghan{3,Interval{Float64}}
+end
 
 # Data in the following tests are from
 # https://github.com/materialsproject/pymatgen/blob/1f0957b8525ddc7d12ea348a19caecebe6c7ff34/pymatgen/analysis/tests/test_eos.py


### PR DESCRIPTION
Closes #14 