### PR TITLE
Distinguish `FiniteStrainEossParam{2}` & `FiniteStrainEossParam{3}`

### DIFF
--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -33,8 +33,6 @@ struct BirchMurnaghan3rd{T} <: FiniteStrainEossParam{3,T}
     e0::T
     BirchMurnaghan3rd{T}(v0, b0, b′0, e0 = zero(v0 * b0)) where {T} = new(v0, b0, b′0, e0)
 end
-BirchMurnaghan3rd(arr::AbstractVector) = BirchMurnaghan3rd{eltype(arr)}(arr...)
-BirchMurnaghan3rd(args...) = BirchMurnaghan3rd([args...])
 struct PoirierTarantola2nd{T} <: FiniteStrainEossParam{2,T}
     v0::T
     b0::T
@@ -102,5 +100,13 @@ function Base.show(io::IO, eos::EossParam)  # Ref: https://github.com/mauro3/Par
         end
     end
 end # function Base.show
+
+for T in
+    (:BirchMurnaghan2nd, :BirchMurnaghan3rd, :PoirierTarantola2nd, :PoirierTarantola3rd)
+    eval(quote
+        $T(arr::AbstractVector) = $T{eltype(arr)}(arr...)
+        $T(args...) = $T([args...])
+    end)
+end
 
 end

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -3,7 +3,10 @@ module Collections
 using AutoHashEquals: @auto_hash_equals
 using UnPack: @unpack
 
-export BirchMurnaghan3rd,
+export BirchMurnaghan2nd,
+    BirchMurnaghan3rd,
+    PoirierTarantola2nd,
+    PoirierTarantola3rd,
     Eulerian,
     Lagrangian,
     Natural,
@@ -17,9 +20,12 @@ export BirchMurnaghan3rd,
     volume_from_strain
 
 abstract type EossParam{T} end
-
 abstract type FiniteStrainEossParam{N,T} <: EossParam{T} end
-
+struct BirchMurnaghan2nd{T} <: FiniteStrainEossParam{2,T}
+    v0::T
+    b0::T
+    e0::T
+end
 struct BirchMurnaghan3rd{T} <: FiniteStrainEossParam{3,T}
     v0::T
     b0::T
@@ -29,6 +35,18 @@ struct BirchMurnaghan3rd{T} <: FiniteStrainEossParam{3,T}
 end
 BirchMurnaghan3rd(arr::AbstractVector) = BirchMurnaghan3rd{eltype(arr)}(arr...)
 BirchMurnaghan3rd(args...) = BirchMurnaghan3rd([args...])
+struct PoirierTarantola2nd{T} <: FiniteStrainEossParam{2,T}
+    v0::T
+    b0::T
+    e0::T
+end
+struct PoirierTarantola3rd{T} <: FiniteStrainEossParam{3,T}
+    v0::T
+    b0::T
+    b′0::T
+    e0::T
+    PoirierTarantola3rd{T}(v0, b0, b′0, e0 = zero(v0 * b0)) where {T} = new(v0, b0, b′0, e0)
+end
 
 abstract type EquationOfStateOfSolids{T<:EossParam} end
 struct EnergyEoss{T} <: EquationOfStateOfSolids{T}


### PR DESCRIPTION
Now it should be clear that

```julia
julia> print_tree(FiniteStrainEossParam)
FiniteStrainEossParam
├─ BirchMurnaghan2nd
├─ BirchMurnaghan3rd
├─ PoirierTarantola2nd
└─ PoirierTarantola3rd

julia> print_tree(FiniteStrainEossParam{2})
FiniteStrainEossParam{2,T} where T
├─ BirchMurnaghan2nd
└─ PoirierTarantola2nd

julia> print_tree(FiniteStrainEossParam{3})
FiniteStrainEossParam{3,T} where T
├─ BirchMurnaghan3rd
└─ PoirierTarantola3rd
```