### PR TITLE
Subtype `EquationOfStateOfSolids` from `EquationOfState`

### DIFF
--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -15,9 +15,9 @@ export Murnaghan,
     Lagrangian,
     Natural,
     Infinitesimal,
-    EnergyEoss,
-    PressureEoss,
-    BulkModulusEoss,
+    EnergyEOS,
+    PressureEOS,
+    BulkModulusEOS,
     orderof,
     nextorder,
     strain_from_volume,
@@ -84,114 +84,115 @@ struct Vinet{T} <: Parameters{T}
     Vinet{T}(v0, b0, b′0, e0 = zero(v0 * b0)) where {T} = new(v0, b0, b′0, e0)
 end
 
-abstract type EquationOfStateOfSolids{T<:EossParam} end
-struct EnergyEoss{T} <: EquationOfStateOfSolids{T}
+abstract type EquationOfState{T<:Parameters} end
+abstract type EquationOfStateOfSolids{T} <: EquationOfState{T} end
+struct EnergyEOS{T} <: EquationOfStateOfSolids{T}
     param::T
 end
-struct PressureEoss{T} <: EquationOfStateOfSolids{T}
+struct PressureEOS{T} <: EquationOfStateOfSolids{T}
     param::T
 end
-struct BulkModulusEoss{T} <: EquationOfStateOfSolids{T}
+struct BulkModulusEOS{T} <: EquationOfStateOfSolids{T}
     param::T
 end
 
-function (eos::EnergyEoss{<:Murnaghan})(v)
+function (eos::EnergyEOS{<:Murnaghan})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     x, y = b′0 - 1, (v0 / v)^b′0
     return e0 + b0 / b′0 * v * (y / x + 1) - v0 * b0 / x
 end
-function (eos::EnergyEoss{<:BirchMurnaghan2nd})(v)
+function (eos::EnergyEOS{<:BirchMurnaghan2nd})(v)
     @unpack v0, b0, e0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     return e0 + 9b0 * v0 * f^2 / 2
 end
-function (eos::EnergyEoss{<:BirchMurnaghan3rd})(v)
+function (eos::EnergyEOS{<:BirchMurnaghan3rd})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     return e0 + 9b0 * v0 * f^2 / 2 * (1 + f * (b′0 - 4))
 end
-function (eos::EnergyEoss{<:BirchMurnaghan4th})(v)
+function (eos::EnergyEOS{<:BirchMurnaghan4th})(v)
     @unpack v0, b0, b′0, b′′0, e0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     h = b′′0 * b0 + b′0^2
     return e0 + 3b0 * v0 / 8 * f^2 * ((9h - 63b′0 + 143) * f^2 + 12f * (b′0 - 4) + 12)
 end
-function (eos::EnergyEoss{<:PoirierTarantola2nd})(v)
+function (eos::EnergyEOS{<:PoirierTarantola2nd})(v)
     @unpack v0, b0, e0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     return e0 + 9b0 * v0 * f^2 / 2
 end
-function (eos::EnergyEoss{<:PoirierTarantola3rd})(v)
+function (eos::EnergyEOS{<:PoirierTarantola3rd})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     return e0 + 9b0 * v0 * f^2 / 2 * ((b′0 - 2) * f + 1)
 end
-function (eos::EnergyEoss{<:PoirierTarantola4th})(v)
+function (eos::EnergyEOS{<:PoirierTarantola4th})(v)
     @unpack v0, b0, b′0, b′′0, e0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     h = b′′0 * b0 + b′0^2
     return e0 + 9b0 * v0 * f^2 * (3f^2 * (h + 3b′0 + 3) + 4f * (b′0 + 2) + 4)
 end
-function (eos::EnergyEoss{<:Vinet})(v)
+function (eos::EnergyEOS{<:Vinet})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     x, y = 1 - (v / v0)^(1 / 3), 3 / 2 * (b′0 - 1)
     return e0 + 9b0 * v0 / y^2 * (1 + (x * y - 1) * exp(x * y))
 end
 
-function (eos::PressureEoss{<:Murnaghan})(v)
+function (eos::PressureEOS{<:Murnaghan})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     return b0 / b′0 * ((v0 / v)^b′0 - 1)
 end
-function (eos::PressureEoss{<:BirchMurnaghan2nd})(v)
+function (eos::PressureEOS{<:BirchMurnaghan2nd})(v)
     @unpack v0, b0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     return 3b0 * f * (2f + 1)^(5 / 2)
 end
-function (eos::PressureEoss{<:BirchMurnaghan3rd})(v)
+function (eos::PressureEOS{<:BirchMurnaghan3rd})(v)
     @unpack v0, b0, b′0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     return 3f / 2 * b0 * (2f + 1)^(5 / 2) * (2 + 3f * (b′0 - 4))
 end
-function (eos::PressureEoss{<:BirchMurnaghan4th})(v)
+function (eos::PressureEOS{<:BirchMurnaghan4th})(v)
     @unpack v0, b0, b′0, b′′0, e0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     h = b′′0 * b0 + b′0^2
     return b0 / 2 * (2f + 1)^(5 / 2) * ((9h - 63b′0 + 143) * f^2 + 9f * (b′0 - 4) + 6)
 end
-function (eos::PressureEoss{<:PoirierTarantola2nd})(v)
+function (eos::PressureEOS{<:PoirierTarantola2nd})(v)
     @unpack v0, b0, e0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     return -3b0 * f * exp(-3f)
 end
-function (eos::PressureEoss{<:PoirierTarantola3rd})(v)
+function (eos::PressureEOS{<:PoirierTarantola3rd})(v)
     @unpack v0, b0, b′0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     return -3b0 / 2 * f * exp(-3f) * (3f * (b′0 - 2) + 1)
 end
-function (eos::PressureEoss{<:PoirierTarantola4th})(v)
+function (eos::PressureEOS{<:PoirierTarantola4th})(v)
     @unpack v0, b0, b′0, b′′0, e0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     h = b′′0 * b0 + b′0^2
     return -3b0 / 2 * f * exp(-3f) * (3f^2 * (h + 3b′0 + 3) + 3f * (b′0 - 2) + 2)
 end
-function (eos::PressureEoss{<:Vinet})(v)
+function (eos::PressureEOS{<:Vinet})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     x, y = (v / v0)^(1 / 3), 3 / 2 * (b′0 - 1)
     return 3b0 / x^2 * (1 - x) * exp(y * (1 - x))
 end
 
-(eos::BulkModulusEoss{<:Murnaghan})(v) = eos.param.b0 + PressureEoss(eos.param)(v)
-function (eos::BulkModulusEoss{<:BirchMurnaghan2nd})(v)
+(eos::BulkModulusEOS{<:Murnaghan})(v) = eos.param.b0 + PressureEOS(eos.param)(v)
+function (eos::BulkModulusEOS{<:BirchMurnaghan2nd})(v)
     @unpack v0, b0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     return b0 * (7f + 1) * (2f + 1)^(5 / 2)
 end
-function (eos::BulkModulusEoss{<:BirchMurnaghan3rd})(v)
+function (eos::BulkModulusEOS{<:BirchMurnaghan3rd})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     return b0 / 2 * (2f + 1)^(5 / 2) * ((27f^2 + 6f) * (b′0 - 4) - 4f + 2)
 end
-function (eos::BulkModulusEoss{<:BirchMurnaghan4th})(v)
+function (eos::BulkModulusEOS{<:BirchMurnaghan4th})(v)
     @unpack v0, b0, b′0, b′′0, e0 = eos.param
     f = strain_from_volume(Eulerian(), v0)(v)
     h = b′′0 * b0 + b′0^2
@@ -199,17 +200,17 @@ function (eos::BulkModulusEoss{<:BirchMurnaghan4th})(v)
            (2f + 1)^(5 / 2) *
            ((99h - 693b′0 + 1573) * f^3 + (27h - 108b′0 + 105) * f^2 + 6f * (3b′0 - 5) + 6)
 end
-function (eos::BulkModulusEoss{<:PoirierTarantola2nd})(v)
+function (eos::BulkModulusEOS{<:PoirierTarantola2nd})(v)
     @unpack v0, b0, e0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     return b0 * (1 - 3f) * exp(-3f)
 end
-function (eos::BulkModulusEoss{<:PoirierTarantola3rd})(v)
+function (eos::BulkModulusEOS{<:PoirierTarantola3rd})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     return -b0 / 2 * exp(-3f) * (9f^2 * (b′0 - 2) - 6f * (b′0 + 1) - 2)
 end
-function (eos::BulkModulusEoss{<:PoirierTarantola4th})(v)
+function (eos::BulkModulusEOS{<:PoirierTarantola4th})(v)
     @unpack v0, b0, b′0, b′′0, e0 = eos.param
     f = strain_from_volume(Natural(), v0)(v)
     h = b′′0 * b0 + b′0^2
@@ -217,7 +218,7 @@ function (eos::BulkModulusEoss{<:PoirierTarantola4th})(v)
            exp(-3f) *
            (9f^3 * (h + 3b′0 + 3) - 9f^2 * (h + 2b′0 + 1) - 6f * (b′0 + 1) - 2)
 end
-function (eos::BulkModulusEoss{<:Vinet})(v)
+function (eos::BulkModulusEOS{<:Vinet})(v)
     @unpack v0, b0, b′0, e0 = eos.param
     x, ξ = (v / v0)^(1 / 3), 3 / 2 * (b′0 - 1)
     return -b0 / (2 * x^2) * (3x * (x - 1) * (b′0 - 1) + 2 * (x - 2)) * exp(-ξ * (x - 1))

--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -23,29 +23,29 @@ export Murnaghan,
     strain_from_volume,
     volume_from_strain
 
-abstract type EossParam{T} end
-abstract type FiniteStrainEossParam{N,T} <: EossParam{T} end
-struct Murnaghan{T} <: EossParam{T}
+abstract type Parameters{T} end
+abstract type FiniteStrainParameters{N,T} <: Parameters{T} end
+struct Murnaghan{T} <: Parameters{T}
     v0::T
     b0::T
     b′0::T
     e0::T
     Murnaghan{T}(v0, b0, b′0, e0 = zero(v0 * b0)) where {T} = new(v0, b0, b′0, e0)
 end
-struct BirchMurnaghan2nd{T} <: FiniteStrainEossParam{2,T}
+struct BirchMurnaghan2nd{T} <: FiniteStrainParameters{2,T}
     v0::T
     b0::T
     e0::T
     BirchMurnaghan2nd{T}(v0, b0, e0 = zero(v0 * b0)) where {T} = new(v0, b0, e0)
 end
-struct BirchMurnaghan3rd{T} <: FiniteStrainEossParam{3,T}
+struct BirchMurnaghan3rd{T} <: FiniteStrainParameters{3,T}
     v0::T
     b0::T
     b′0::T
     e0::T
     BirchMurnaghan3rd{T}(v0, b0, b′0, e0 = zero(v0 * b0)) where {T} = new(v0, b0, b′0, e0)
 end
-struct BirchMurnaghan4th{T} <: FiniteStrainEossParam{4,T}
+struct BirchMurnaghan4th{T} <: FiniteStrainParameters{4,T}
     v0::T
     b0::T
     b′0::T
@@ -54,20 +54,20 @@ struct BirchMurnaghan4th{T} <: FiniteStrainEossParam{4,T}
     BirchMurnaghan4th{T}(v0, b0, b′0, b′′0, e0 = zero(v0 * b0)) where {T} =
         new(v0, b0, b′0, b′′0, e0)
 end
-struct PoirierTarantola2nd{T} <: FiniteStrainEossParam{2,T}
+struct PoirierTarantola2nd{T} <: FiniteStrainParameters{2,T}
     v0::T
     b0::T
     e0::T
     PoirierTarantola2nd{T}(v0, b0, e0 = zero(v0 * b0)) where {T} = new(v0, b0, e0)
 end
-struct PoirierTarantola3rd{T} <: FiniteStrainEossParam{3,T}
+struct PoirierTarantola3rd{T} <: FiniteStrainParameters{3,T}
     v0::T
     b0::T
     b′0::T
     e0::T
     PoirierTarantola3rd{T}(v0, b0, b′0, e0 = zero(v0 * b0)) where {T} = new(v0, b0, b′0, e0)
 end
-struct PoirierTarantola4th{T} <: FiniteStrainEossParam{4,T}
+struct PoirierTarantola4th{T} <: FiniteStrainParameters{4,T}
     v0::T
     b0::T
     b′0::T
@@ -76,7 +76,7 @@ struct PoirierTarantola4th{T} <: FiniteStrainEossParam{4,T}
     PoirierTarantola4th{T}(v0, b0, b′0, b′′0, e0 = zero(v0 * b0)) where {T} =
         new(v0, b0, b′0, b′′0, e0)
 end
-struct Vinet{T} <: EossParam{T}
+struct Vinet{T} <: Parameters{T}
     v0::T
     b0::T
     b′0::T
@@ -223,7 +223,7 @@ function (eos::BulkModulusEoss{<:Vinet})(v)
     return -b0 / (2 * x^2) * (3x * (x - 1) * (b′0 - 1) + 2 * (x - 2)) * exp(-ξ * (x - 1))
 end
 
-orderof(::FiniteStrainEossParam{N}) where {N} = N
+orderof(::FiniteStrainParameters{N}) where {N} = N
 
 abstract type FiniteStrain end  # Trait
 struct Eulerian <: FiniteStrain end
@@ -241,7 +241,7 @@ volume_from_strain(::Lagrangian, v0) = f -> v0 * (2f + 1)^(3 / 2)
 volume_from_strain(::Natural, v0) = f -> v0 * exp(3f)
 volume_from_strain(::Infinitesimal, v0) = f -> v0 / (1 - f)^3
 
-function Base.show(io::IO, eos::EossParam)  # Ref: https://github.com/mauro3/Parameters.jl/blob/3c1d72b/src/Parameters.jl#L542-L549
+function Base.show(io::IO, eos::Parameters)  # Ref: https://github.com/mauro3/Parameters.jl/blob/3c1d72b/src/Parameters.jl#L542-L549
     if get(io, :compact, false)
         Base.show_default(IOContext(io, :limit => true), eos)
     else
@@ -254,7 +254,7 @@ function Base.show(io::IO, eos::EossParam)  # Ref: https://github.com/mauro3/Par
     end
 end # function Base.show
 
-(::Type{T})(arr::AbstractVector) where {T<:EossParam} = T{eltype(arr)}(arr...)
-(::Type{T})(args...) where {T<:EossParam} = T([args...])
+(::Type{T})(arr::AbstractVector) where {T<:Parameters} = T{eltype(arr)}(arr...)
+(::Type{T})(args...) where {T<:Parameters} = T([args...])
 
 end

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -5,8 +5,7 @@ using LsqFit: curve_fit, coef
 using Serialization: serialize
 using Setfield: @set!
 
-using ..Collections:
-    EquationOfStateOfSolids, FiniteStrainEossParam, PressureEoss, EnergyEoss
+using ..Collections: EquationOfStateOfSolids, FiniteStrainParameters, PressureEOS, EnergyEOS
 
 export linfit, nonlinfit
 
@@ -66,7 +65,7 @@ function checkparam(param::FiniteStrainParameters)  # Do not export!
 end
 
 initparam(eos, ::Any) = fieldvalues(eos.param)
-function initparam(eos::EnergyEoss, energies)
+function initparam(eos::EnergyEOS, energies)
     if iszero(eos.param.e0)
         @set! eos.param.e0 = minimum(energies)
     end

--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -56,7 +56,7 @@ function createmodel(::S) where {T,S<:EquationOfStateOfSolids{T}}  # Do not expo
     return (x, p) -> map(constructor(p), x)
 end
 
-function checkparam(param::FiniteStrainEossParam)  # Do not export!
+function checkparam(param::FiniteStrainParameters)  # Do not export!
     if param.v0 <= zero(param.v0) || param.b0 <= zero(param.b0)
         @error "fitted `v0` or `b0` is negative!"
     end

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -6,12 +6,13 @@ using Roots: find_zero, AbstractBracketing, AbstractUnivariateZeroMethod
 using UnPack: @unpack
 
 using ..Collections:
-    PressureEoss,
-    EnergyEoss,
+    PressureEOS,
+    EnergyEOS,
     EquationOfStateOfSolids,
     Murnaghan,
     BirchMurnaghan2nd,
-    BirchMurnaghan3rd
+    BirchMurnaghan3rd,
+    PoirierTarantola3rd
 
 export findvolume
 
@@ -25,11 +26,11 @@ _nonabstract(t::Type) = filter(!isabstracttype, _allsubtypes(t))  # `Roots.False
 
 const ROOT_FINDING_ALGORITHMS = _nonabstract(AbstractUnivariateZeroMethod)
 
-function findvolume(eos::PressureEoss{<:Murnaghan}, p)
+function findvolume(eos::PressureEOS{<:Murnaghan}, p)
     @unpack v0, b0, b′0, e0 = eos.param
     return v0 * (1 + b′0 / b0 * p)^(-1 / b′0)
 end
-function findvolume(eos::EnergyEoss{<:BirchMurnaghan2nd}, e)
+function findvolume(eos::EnergyEOS{<:BirchMurnaghan2nd}, e)
     @unpack v0, b0, b′0, e0 = eos.param
     f = sqrt(2 / 9 * (e - e0) / b0 / v0)
     vs = map(volume_from_strain(Eulerian(), v0), [f, -f])


### PR DESCRIPTION
I always think `EquationOfStateOfSolids` looks ugly but necessary so this package's scope is limited. I find a way to work around, invent `EquationOfState` and subtype `EquationOfStateOfSolids` from it. In the future I will have a base package like `EquationsOfState.jl`, and that's what it contains `EquationOfState`.

- Add type `EquationOfState`
- Subtype `EquationOfStateOfSolids` from `EquationOfState`
- Rename `EnergyEoss` to `EnergyEOS`
- Rename `PressureEoss` to `PressureEOS`
- Rename `BulkModulusEoss` to `BulkModulusEOS`
- Rename `EossParam` back to `Parameters` because `Eoss` is repeated in `PressureEoss{<:EossParam}`