### PR TITLE
Replace old `findvolume` for `EnergyEos{<:BirchMurnaghan3rd}` with the analytical one

### DIFF
--- a/src/Collections.jl
+++ b/src/Collections.jl
@@ -475,8 +475,34 @@ Return a function of `f` that calculates the corresponding volume from `v0`.
 !!! info
     See the formulae on Ref. 1 Table 3.
 """
-strain2volume(::EulerianStrain, v0) = f -> v0 / (2f + 1)^_1½
-strain2volume(::LagrangianStrain, v0) = f -> v0 * (2f + 1)^_1½
+function strain2volume(::EulerianStrain, v0)
+    return function (f)
+        if isreal(f)
+            f = real(f)
+        else
+            throw(DomainError("strain cannot be complex!"))
+        end
+        if f < -1 / 2
+            v0 / Complex(2f + 1)^(3 / 2)
+        else
+            v0 / (2f + 1)^_1½
+        end
+    end
+end
+function strain2volume(::LagrangianStrain, v0)
+    return function (f)
+        if isreal(f)
+            f = real(f)
+        else
+            throw(DomainError("strain cannot be complex!"))
+        end
+        if f < -1 / 2
+            v0 * Complex(2f + 1)^(3 / 2)
+        else
+            v0 * (2f + 1)^_1½
+        end
+    end
+end
 strain2volume(::NaturalStrain, v0) = f -> v0 * exp(3f)
 strain2volume(::InfinitesimalStrain, v0) = f -> v0 / (1 - f)^3
 

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -50,7 +50,7 @@ end
 function findvolume(eos::EnergyEos{<:BirchMurnaghan2nd}, e)
     @unpack v0, b0, b′0, e0 = getparam(eos)
     f = sqrt(2 / 9 * (e - e0) / b0 / v0)
-    vs = map(strain2volume(EulerianStrain(), v0), [f, -f])
+    vs = map(strain2volume(EulerianStrain(), v0), (f, -f))
     return map(real, filter(isreal, vs))
 end
 function findvolume(eos::EnergyEos{<:BirchMurnaghan3rd}, e; root_thr = 1e-20)

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -41,7 +41,7 @@ using ..Collections:
     strain2volume,
     getparam
 
-export findvolume, mustfindvolume, findvolume2
+export findvolume, mustfindvolume
 
 function findvolume(eos::PressureEos{<:Murnaghan}, p)
     @unpack v0, b0, b′0, e0 = getparam(eos)
@@ -53,17 +53,7 @@ function findvolume(eos::EnergyEos{<:BirchMurnaghan2nd}, e)
     vs = map(strain2volume(EulerianStrain(), v0), (f, -f))
     return map(real, filter(isreal, vs))
 end
-function findvolume(eos::EnergyEos{<:BirchMurnaghan3rd}, e; root_thr = 1e-20)
-    @unpack v0, b0, b′0, e0 = getparam(eos)
-    # Constrcut ax^3 + bx^2 + d = 0
-    b, d = 9 / 2 * b0 * v0, e0 - e
-    a = b * (b′0 - 4)
-    # Solve ax^3 + bx^2 + d = 0
-    fs = roots([d, 0, b, a]; polish = true, epsilon = root_thr)
-    vs = map(strain2volume(EulerianStrain(), v0), fs)
-    return map(real, filter(isreal, vs))
-end
-function findvolume2(eos::EnergyEos{<:BirchMurnaghan3rd}, e)
+function findvolume(eos::EnergyEos{<:BirchMurnaghan3rd}, e)
     @unpack v0, b0, b′0, e0 = getparam(eos)
     # Constrcut ax^3 + bx^2 + d = 0, see https://zh.wikipedia.org/wiki/%E4%B8%89%E6%AC%A1%E6%96%B9%E7%A8%8B#%E6%B1%82%E6%A0%B9%E5%85%AC%E5%BC%8F%E6%B3%95
     a = b′0 - 4

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -41,7 +41,7 @@ using ..Collections:
     strain2volume,
     getparam
 
-export findvolume, mustfindvolume
+export findvolume, mustfindvolume, findvolume2
 
 function findvolume(eos::PressureEos{<:Murnaghan}, p)
     @unpack v0, b0, b′0, e0 = getparam(eos)
@@ -62,6 +62,29 @@ function findvolume(eos::EnergyEos{<:BirchMurnaghan3rd}, e; root_thr = 1e-20)
     fs = roots([d, 0, b, a]; polish = true, epsilon = root_thr)
     vs = map(strain2volume(EulerianStrain(), v0), fs)
     return map(real, filter(isreal, vs))
+end
+function findvolume2(eos::EnergyEos{<:BirchMurnaghan3rd}, e)
+    @unpack v0, b0, b′0, e0 = getparam(eos)
+    # Constrcut ax^3 + bx^2 + d = 0, see https://zh.wikipedia.org/wiki/%E4%B8%89%E6%AC%A1%E6%96%B9%E7%A8%8B#%E6%B1%82%E6%A0%B9%E5%85%AC%E5%BC%8F%E6%B3%95
+    a = b′0 - 4
+    r = 1 / 3a  # b = 1
+    d = (e0 - e) / (9 / 2 * b0 * v0)
+    p, q = -r^3 - d / 2a, -r^2
+    Δ = p^2 + q^3
+    fs = -r .+ if Δ < 0
+        SIN, COS = sincos(acos(p / abs(r)^3) / 3)
+        (2COS, -COS - √3 * SIN, -COS + √3 * SIN) .* abs(r)  # Verified
+    elseif Δ == 0
+        if p == q == 0
+            (0,)  # 3 reals are equal
+        else  # p == -q != 0
+            2cbrt(p), -cbrt(p)  # 2 real roots are equal, leaving 2 solutions
+        end
+    else  # Δ > 0
+        (cbrt(p + √Δ) + cbrt(p - √Δ),)  # Only 1 real solution
+    end  # solutions are strains
+    vs = map(strain2volume(EulerianStrain(), v0), fs)
+    return filter(_ispositive, map(real, filter(isreal, vs)))
 end
 function findvolume(
     eos::EquationOfStateOfSolids,


### PR DESCRIPTION
The new [`findvolume`](https://github.com/MineralsCloud/EquationsOfStateOfSolids.jl/blob/2f6365a8da65376e0ab52b03093cb41093fa7f6d/src/Volume.jl#L56-L78) is much faster & do not give complex strains.