### PR TITLE
Rewrite constructors of `Parameters`

### DIFF
--- a/src/collections/collections.jl
+++ b/src/collections/collections.jl
@@ -61,8 +61,11 @@ function Base.show(io::IO, param::Parameters)  # Ref: https://github.com/mauro3/
     end
 end
 
-(::Type{T})(arr::AbstractVector) where {T<:Parameters} = T{eltype(arr)}(arr...)
-(::Type{T})(args...) where {T<:Parameters} = T([args...])
+function (::Type{T})(args...) where {T<:Parameters}
+    E = Base.promote_typeof(args...)
+    return constructorof(T){E}(args...)  # Cannot use `T.(args...)`! For `AbstractQuantity` they will fail!
+end
+(::Type{T})(arr::AbstractVector) where {T<:Parameters} = T(arr...)
 function Murnaghan(args...)
     N = length(args)
     if N == 4


### PR DESCRIPTION
In PR #34 I deprecated [the old way of writing constructors](https://github.com/MineralsCloud/EquationsOfState.jl/blob/5566e7e5b48e8b6d01f9f2762eee2d207d6fc364/src/Collections.jl#L80-L83). However, using `Vector`s to promote `eltype` seems to cause #88, so I now revert it back.

BTW, the old way can be simplified without `conver`sions since the constructor will convert eltypes to `T` automatically.