### PR TITLE
Deprecate constructing `Parameters` from an `AbstractVector`

### DIFF
--- a/src/Fitting.jl
+++ b/src/Fitting.jl
@@ -198,7 +198,7 @@ end
 
 # Do not export!
 buildmodel(eos::EquationOfStateOfSolids{T}) where {T} =
-    (x, p...) -> constructorof(typeof(eos))(constructorof(T)(p...)).(x)
+    (x, p) -> constructorof(typeof(eos))(constructorof(T)(p...)).(x)
 
 function checkresult(p::Parameters)  # Do not export!
     if p.v0 <= zero(p.v0) || p.b0 <= zero(p.b0)

--- a/src/collections/collections.jl
+++ b/src/collections/collections.jl
@@ -65,7 +65,6 @@ function (::Type{T})(args...) where {T<:Parameters}
     E = Base.promote_typeof(args...)
     return constructorof(T){E}(args...)  # Cannot use `T.(args...)`! For `AbstractQuantity` they will fail!
 end
-(::Type{T})(arr::AbstractVector) where {T<:Parameters} = T(arr...)
 function Murnaghan(args...)
     N = length(args)
     if N == 4

--- a/src/collections/types.jl
+++ b/src/collections/types.jl
@@ -1,8 +1,8 @@
 abstract type EquationOfStateOfSolidsParameters{T} end
-abstract type FiniteStrainParameters{N,T} <: EquationOfStateOfSolidsParameters{T} end
+const Parameters = EquationOfStateOfSolidsParameters
+abstract type FiniteStrainParameters{N,T} <: Parameters{T} end
 abstract type BirchMurnaghan{N,T} <: FiniteStrainParameters{N,T} end
 abstract type PoirierTarantola{N,T} <: FiniteStrainParameters{N,T} end
-const Parameters = EquationOfStateOfSolidsParameters
 """
     Murnaghan(v0, b0, b′0, e0=zero(v0 * b0))
 


### PR DESCRIPTION
Let's see what troubles it would cause