### PR TITLE
Big changes in module `FiniteStrains`

### DIFF
--- a/src/FiniteStrains.jl
+++ b/src/FiniteStrains.jl
@@ -43,7 +43,7 @@ julia> g ∘ f == f ∘ g == identity
 true
 ```
 """
-struct StrainFromVolume{S<:FiniteStrain,T}
+struct StrainFromVolume{S<:FiniteStrain,T<:Number}
     v0::T
 end
 StrainFromVolume{S}(v0::T) where {S,T} = StrainFromVolume{S,T}(v0)
@@ -82,7 +82,7 @@ julia> f ∘ g == g ∘ f == identity
 true
 ```
 """
-struct VolumeFromStrain{S<:FiniteStrain,T}
+struct VolumeFromStrain{S<:FiniteStrain,T<:Number}
     v0::T
 end
 VolumeFromStrain{S}(v0::T) where {S,T} = VolumeFromStrain{S,T}(v0)

--- a/src/FiniteStrains.jl
+++ b/src/FiniteStrains.jl
@@ -164,6 +164,4 @@ function Dⁿᵥf(s::Infinitesimal, deg, v0)
     end
 end
 
-function straintype end
-
 end

--- a/src/collections/collections.jl
+++ b/src/collections/collections.jl
@@ -1,9 +1,10 @@
 using Functors: fmap
 
-using .FiniteStrains: EulerianStrainFromVolume, NaturalStrainFromVolume, Eulerian, Natural
+using .FiniteStrains: EulerianStrainFromVolume, NaturalStrainFromVolume
 
 import Unitful: ustrip
-import .FiniteStrains: straintype
+
+import .FiniteStrains: VolumeFromStrain, StrainFromVolume
 
 export orderof
 
@@ -59,10 +60,6 @@ function Base.show(io::IO, eos::EquationOfStateOfSolids)
     end
 end
 
-straintype(::Type{<:BirchMurnaghan}) = EulerianStrain
-straintype(::Type{<:PoirierTarantola}) = NaturalStrain
-straintype(x::FiniteStrainParameters) = straintype(typeof(x))
-
 Base.eltype(::Type{<:Parameters{T}}) where {T} = T
 
 """
@@ -92,3 +89,9 @@ Base.real(p::Parameters) = fmap(real, p)  # Not used but may be useful
 Strip units from a `Parameters`.
 """
 ustrip(p::Parameters) = fmap(ustrip, p)
+
+VolumeFromStrain(::BirchMurnaghan) = EulerianStrainFromVolume
+VolumeFromStrain(::PoirierTarantola) = NaturalStrainFromVolume
+
+StrainFromVolume(::BirchMurnaghan) = EulerianStrainFromVolume
+StrainFromVolume(::PoirierTarantola) = NaturalStrainFromVolume


### PR DESCRIPTION
- Deprecate method `straintype`, use `VolumeFromStrain` & `StrainFromVolume` constructors
- Rewrite `Dⁿᵥf` to `DerivativeOfStrain`
- Add intermediate type `StrainFromVolumeWithReferenceVolume` & `VolumeFromStrainWithReferenceVolume`